### PR TITLE
ExperimentHubData 1.39.1: Drop dependency on utils

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ExperimentHubData
 Type: Package
 Title: Add resources to ExperimentHub
-Version: 1.39.0
+Version: 1.39.1
 Authors@R:
     c(person("Bioconductor", "Maintainer",
 	     email="maintainer@bioconductor.org", role="cre"))
@@ -9,10 +9,8 @@ Maintainer: Bioconductor Package Maintainer <maintainer@bioconductor.org>
 Description: Functions to add metadata to ExperimentHub db and
     resource files to AWS S3 buckets.
 License: Artistic-2.0
-Depends: utils, BiocGenerics (>= 0.15.10), S4Vectors,
-    AnnotationHubData (>= 1.21.3)
-Imports: methods, ExperimentHub, BiocManager, DBI, httr,
-    curl
+Depends: BiocGenerics (>= 0.15.10), S4Vectors, AnnotationHubData (>= 1.21.3)
+Imports: methods, ExperimentHub, BiocManager, DBI, httr, curl
 Suggests: GenomeInfoDb, RUnit, knitr, BiocStyle, rmarkdown, HubPub
 biocViews: Infrastructure, DataImport, GUI, ThirdPartyClient
 VignetteBuilder: knitr

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,5 +1,4 @@
 import(methods)
-import(utils)
 import(BiocGenerics)
 import(S4Vectors)
 import(httr)


### PR DESCRIPTION
Package **utils** doesn't seem to be used anywhere in **ExperimentHubData**, so can go away. This will also make the following `R CMD check` warnings go away:
```
* checking whether package ‘ExperimentHubData’ can be installed ... WARNING
Found the following significant warnings:
  Warning: replacing previous import ‘utils::data’ by ‘BiocGenerics::data’ when loading ‘ExperimentHubData’
  Warning: replacing previous import ‘utils::findMatches’ by ‘S4Vectors::findMatches’ when loading ‘ExperimentHubData’
```
See https://bioconductor.org/checkResults/3.24/bioc-rapid-LATEST/ExperimentHubData/teran2-checksrc.html